### PR TITLE
Fix php script error

### DIFF
--- a/framework/cli-script.php
+++ b/framework/cli-script.php
@@ -1,3 +1,3 @@
 <?php
 
-echo "fragmenting core-dumps..."
+echo "fragmenting core-dumps...";


### PR DESCRIPTION
In PHP, statements must be terminated with a ;