### PR TITLE
remove cli-script.php

### DIFF
--- a/framework/cli-script.php
+++ b/framework/cli-script.php
@@ -1,3 +1,0 @@
-<?php
-
-echo "fragmenting core-dumps...";


### PR DESCRIPTION
Certain platform reads the output from example.. dev/build to decide if the command was sucessful
so instead of faking it, I hereby withdraw my suggestion of using it in the first place